### PR TITLE
Add MoSiC talk details for Mohammadreza Salehi

### DIFF
--- a/src/data/home.json
+++ b/src/data/home.json
@@ -69,9 +69,9 @@
         },
         {
           "time": "14:00 - 14:15",
-          "session": "",
+          "session": "MoSiC: Optimal-Transport Motion Trajectory for Dense Self-Supervised Learning",
           "presenter": "Mohammadreza Salehi (UvA)",
-          "sessionUrl": "",
+          "sessionUrl": "https://docs.google.com/presentation/d/1BZRLA1S7vNmEcvINIY7GTfP-HrjKHviOZnQ7zds6Agk/edit?usp=sharing",
           "presenterUrl": "https://smsd75.github.io/"
         },
         {


### PR DESCRIPTION
## Summary
- update Mohammadreza Salehi's session title to "MoSiC: Optimal-Transport Motion Trajectory for Dense Self-Supervised Learning"
- link the session entry to the provided Google Slides presentation

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d4484a6b3c8326a052349d02536aa0