### PR TITLE
Update Hubert P. H. Shum session title

### DIFF
--- a/src/data/home.json
+++ b/src/data/home.json
@@ -97,7 +97,7 @@
         },
         {
           "time": "15:30 - 15:45",
-          "session": "",
+          "session": "Visual Data Learning from Limited Datasets via Geometric Feature-Based Transfer Learning",
           "presenter": "Hubert P. H. Shum (Durham)",
           "sessionUrl": "",
           "presenterUrl": "https://hubertshum.com/"


### PR DESCRIPTION
## Summary
- update the session title for Hubert P. H. Shum to "Visual Data Learning from Limited Datasets via Geometric Feature-Based Transfer Learning"

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d4dc425c7483268aa86d4541e90737